### PR TITLE
Reverse order

### DIFF
--- a/data/pdfshuffler.ui
+++ b/data/pdfshuffler.ui
@@ -163,6 +163,16 @@
                         <signal name="activate" handler="clear_selected" swapped="no"/>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="imagemenuitem_reverse_order">
+                        <property name="label" translatable="yes">Reverse Order</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="reverse_order" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/pdfshuffler/pdfshuffler.py
+++ b/pdfshuffler/pdfshuffler.py
@@ -255,9 +255,10 @@ class PdfShuffler:
         # Creating the popup menu
         self.popup = Gtk.Menu()
         labels = (_('_Rotate Right'), _('Rotate _Left'), _('C_rop...'),
-                  _('_Delete'), _('_Export selection...'))
+                  _('_Delete'), _('Re_verse Order'), _('_Export selection...'))
         cbs = (self.rotate_page_right, self.rotate_page_left,
                self.crop_page_dialog, self.clear_selected,
+               self.reverse_order,
                self.choose_export_selection_pdf_name)
         for label, cb in zip(labels, cbs):
            popup_item = Gtk.MenuItem.new_with_mnemonic(label)
@@ -1030,6 +1031,28 @@ class PdfShuffler:
         elif result == Gtk.ResponseType.CANCEL:
             print(_('Dialog closed'))
         dialog.destroy()
+
+    def reverse_order(self, widget, data=None):
+        """Reverses the selected elements in the IconView"""
+        # must be a contiguous selection
+
+        model = self.iconview.get_model()
+        selection = self.iconview.get_selected_items()
+        if len(selection) < 2:
+            return
+
+        # selection is a list of 1-tuples, not in order
+        indices = sorted([i[0] for i in selection])
+        first = indices[0]
+        last = indices[-1]
+        contiguous = (len(indices) == last - first + 1)
+        if not contiguous:
+            return
+
+        self.set_unsaved(True)
+        indices.reverse()
+        new_order = range(first) + indices + range(last + 1, len(model))
+        model.reorder(new_order)
 
     def about_dialog(self, widget, data=None):
         about_dialog = Gtk.AboutDialog()


### PR DESCRIPTION
Hi, Jerome. I found a need to reverse the order of a stack of bank statements that I had scanned, where I had kept the paper copies in reverse order, so I have written this patch to do it in PdfShuffler. I think it would be a useful addition.

It adds an item under 'Edit' menu and in the popup menu called 'Reverse Order', which is sensitive when multiple contiguous pages are selected, and it reverses their order.

I think bug fixes relating to selection and drag-and-drop are more important than this, and have been trying to work on those too, but this reverse-order enhancement is the first patch I am happy with.

Please let me know if this is something you could accept. Thanks.
